### PR TITLE
Øker font-size og line-height 

### DIFF
--- a/templates/amt/style.hbs
+++ b/templates/amt/style.hbs
@@ -8,8 +8,8 @@
     }
     * {
         font-family: "Source Sans 3", SourceSans3, Source_Sans_3, ArialSystem, sans-serif;
-        font-size: 11px;
-        line-height: 16px;
+        font-size: 13px;
+        line-height: 20px;
         box-sizing: border-box;
     }
     section {


### PR DESCRIPTION
For å gjøre det visuelt likere skissene fram til vi finner ut hvorfor skrifta ser så liten ut med samme styling som i de visuelle retningslinjene.