### PR TITLE
Fikser brevtitler

### DIFF
--- a/data/amt/endringsvedtak.json
+++ b/data/amt/endringsvedtak.json
@@ -64,6 +64,9 @@
     "navn": "Veileder Veiledersen",
     "enhet": "NAV Fyrstikkaleen"
   },
+  "sidetittel": "Arbeidsforberedende trening hos Muligheter AS",
+  "ingressnavn": "Arbeidsforberedende trening hos Muligheter AS",
+  "opprettetDato": "2025-04-30",
   "vedtaksdato": "2024-05-03",
   "forsteVedtakFattet": "2024-04-30"
 }

--- a/data/amt/hovedvedtak-kurs.json
+++ b/data/amt/hovedvedtak-kurs.json
@@ -25,7 +25,7 @@
         "enhet": "NAV Fyrstikkaleen"
     },
     "sidetittel": "Digitalt jobbsøkerkurs hos Muligheter AS",
-    "ingressnavn": "Digitalt jobbsøkerkurs hos Muligheter AS",
+    "ingressnavn": "Norskkurs hos Muligheter AS",
     "opprettetDato": "2024-04-30",
     "vedtaksdato": "2024-04-30",
     "begrunnelseFraNav": "Det er riktig å delta på dette tiltaket likevel"

--- a/data/amt/hovedvedtak-kurs.json
+++ b/data/amt/hovedvedtak-kurs.json
@@ -24,6 +24,9 @@
         "navn": "Veileder Veiledersen",
         "enhet": "NAV Fyrstikkaleen"
     },
+    "sidetittel": "Digitalt jobbsøkerkurs hos Muligheter AS",
+    "ingressnavn": "Digitalt jobbsøkerkurs hos Muligheter AS",
+    "opprettetDato": "2024-04-30",
     "vedtaksdato": "2024-04-30",
     "begrunnelseFraNav": "Det er riktig å delta på dette tiltaket likevel"
 }

--- a/data/amt/hovedvedtak-vta.json
+++ b/data/amt/hovedvedtak-vta.json
@@ -25,6 +25,9 @@
         "navn": "Veileder Veiledersen",
         "enhet": "NAV Fyrstikkaleen"
     },
+    "sidetittel": "Varig tilrettelagt arbeid hos Muligheter AS",
+    "ingressnavn": "Varig tilrettelagt arbeid hos Muligheter AS",
+    "opprettetDato": "2024-04-30",
     "vedtaksdato": "2024-04-30",
     "begrunnelseFraNav": "Det er riktig å delta på dette tiltaket likevel"
 }

--- a/data/amt/hovedvedtak.json
+++ b/data/amt/hovedvedtak.json
@@ -29,6 +29,9 @@
         "navn": "Veileder Veiledersen",
         "enhet": "NAV Fyrstikkaleen"
     },
+    "sidetittel": "Varig tilrettelagt arbeid hos Muligheter AS",
+    "ingressnavn": "Varig tilrettelagt arbeid hos Muligheter AS",
+    "opprettetDato": "2024-04-30",
     "vedtaksdato": "2024-04-30",
     "begrunnelseFraNav": "Det er riktig å delta på dette tiltaket likevel"
 }

--- a/data/amt/innsokingsbrev.json
+++ b/data/amt/innsokingsbrev.json
@@ -18,5 +18,9 @@
     "avsender": {
         "navn": "Veileder Veiledersen",
         "enhet": "NAV Fyrstikkaleen"
-    }
+    },
+    "sidetittel": "Fag- og yrkesopplæring hos Muligheter AS",
+    "ingressnavn": "Sveisekurs hos Muligheter AS",
+    "opprettetDato": "2024-04-30"
+
 }

--- a/templates/amt/endringsvedtak.hbs
+++ b/templates/amt/endringsvedtak.hbs
@@ -18,8 +18,8 @@
     </div>
     {{> amt/sections/header}}
     <main>
-        <h1>Endring: {{deltakerliste.navn}}</h1>
-        <p>Du ble meldt på arbeidsmarkedstiltaket {{deltakerliste.navn}} {{iso_to_long_date this.forsteVedtakFattet}}, og deltakelsen er nå endret. Du, arrangør og NAV ser samme informasjon. </p>
+        <h1>Endring: {{this.sidetittel}}</h1>
+        <p>Du ble meldt på arbeidsmarkedstiltaket {{this.ingressnavn}} {{iso_to_long_date this.forsteVedtakFattet}}, og deltakelsen er nå endret. Du, arrangør og NAV ser samme informasjon. </p>
         {{#each endringer}}
             <section>
                 <h2>{{this.tittel}}</h2>

--- a/templates/amt/hovedvedtak-vta.hbs
+++ b/templates/amt/hovedvedtak-vta.hbs
@@ -19,9 +19,9 @@
     {{> amt/sections/header}}
     <main>
         <section>
-            <h1>{{deltakerliste.navn}}</h1>
+            <h1>{{this.sidetittel}}</h1>
             <p>
-                Du er meldt på arbeidsmarkedstiltaket: {{deltakerliste.navn}}.
+                Du er meldt på arbeidsmarkedstiltaket: {{this.ingressnavn}}.
                 {{deltakerliste.arrangor.navn}} avgjør om du tilbys plass. Ved tilbud om plass vil du bli ansatt.
                 Når arrangøren har en ledig plass så vil de ta kontakt med deg for å avtale oppstart.
             </p>

--- a/templates/amt/innsokingsbrev.hbs
+++ b/templates/amt/innsokingsbrev.hbs
@@ -27,7 +27,7 @@
         </section>
 
         {{#eq deltakerliste.tiltakskode "JOBBKLUBB"}}
-            {{> amt/sections/innhold-med-beskrivelsestekst}}
+            {{> amt/sections/innhold-med-beskrivelsetekst}}
         {{/eq}}
 
         <section>

--- a/templates/amt/innsokingsbrev.hbs
+++ b/templates/amt/innsokingsbrev.hbs
@@ -22,8 +22,8 @@
     <main>
 
         <section>
-            <h1>{{deltakerliste.navn}}</h1>
-            <p>Du er søkt inn på arbeidsmarkedstiltaket: {{deltakerliste.navn}}.</p>
+            <h1>{{this.sidetittel}}</h1>
+            <p>Du er søkt inn på arbeidsmarkedstiltaket: {{this.ingressnavn}}.</p>
         </section>
 
         {{#eq deltakerliste.tiltakskode "JOBBKLUBB"}}

--- a/templates/amt/sections/header.hbs
+++ b/templates/amt/sections/header.hbs
@@ -13,7 +13,7 @@
             </tr>
         </table>
         <div class="vedtaksdato">
-            <p>{{iso_to_long_date this.vedtaksdato}}</p>
+            <p>{{iso_to_long_date this.opprettetDato}}</p>
         </div>
     </div>
 </header>

--- a/templates/amt/sections/overskrift-med-ingress.hbs
+++ b/templates/amt/sections/overskrift-med-ingress.hbs
@@ -1,7 +1,7 @@
 <section>
-    <h1>{{deltakerliste.navn}}</h1>
+    <h1>{{this.sidetittel}}</h1>
     <p>
-        Du er meldt på arbeidsmarkedstiltaket: {{deltakerliste.navn}}.
+        Du er meldt på arbeidsmarkedstiltaket: {{this.ingressnavn}}.
         Når arrangøren har en ledig plass så vil de ta kontakt med deg for å avtale oppstart.
     </p>
     {{> amt/sections/begrunnelse-fra-nav}}


### PR DESCRIPTION
* brevene kan ha forskjellig navn på gjennomføring utifra om det er sidetittel eller i ingress
* innsøkingsbrev også får en dato, slutter å bruke vedtaksdato siden disse har ikke vedtak
https://github.com/navikt/amt-distribusjon/pull/257
https://trello.com/c/0m8P1j5M/2207-lage-brev-for-s%C3%B8kt-inn